### PR TITLE
fix: update is_ppo flag

### DIFF
--- a/nlrl/policy/llm_policy.py
+++ b/nlrl/policy/llm_policy.py
@@ -26,7 +26,7 @@ class Agent:
         self.tp_size = model_tp_size
         self.sample_config = sample_config
         self.is_gpt4 = "gpt-4" in model_path.lower()
-        self.is_ppo = "ppo" in model_path.lower()
+        self.is_ppo = "-ppo" in model_path.lower()
         print(f"model_path: {model_path}, is_gpt4: {self.is_gpt4}, is_ppo: {self.is_ppo}")
 
         if self.is_gpt4:


### PR DESCRIPTION
This pull request includes a small but important change to the `nlrl/policy/llm_policy.py` file. The change corrects the condition used to determine if the model is a PPO model.

* [`nlrl/policy/llm_policy.py`](diffhunk://#diff-e0b17a021faf01134f909c6a2422583f5f5dfcf5cc42ab7a3e612ead87165d3dL29-R29): Modified the condition to check for "-ppo" instead of "ppo" in the model path to accurately set the `is_ppo` attribute.